### PR TITLE
Add boolean detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The value of `preload("res://example.csv").records` will be:
 ```gdscript
 # By default
 [
-	["Apple", "Banana", "Cherry", "Durian", "Feijoa", "Eggplant"],
+	["Apple", "Banana", "Cherry", "Durian", "Eggplant", "Feijoa"],
 	["-12", "13", "14.0", "20.5", "TRUE", "False"],
 ]
 
@@ -64,26 +64,26 @@ The value of `preload("res://example.csv").records` will be:
 		"Banana": "13",
 		"Cherry": "14.0",
 		"Durian": "20.5",
-		"Feijoa": "TRUE",
-		"Eggplant": "False,
+		"Eggplant": "TRUE",
+		"Feijoa": "False",
 	},
 ]
 
 # With "Detect Numbers" and "Force Float" enabled
 [
-	["Apple", "Banana", "Cherry", "Durian", "Feijoa", "Eggplant"],
+	["Apple", "Banana", "Cherry", "Durian", "Eggplant", "Feijoa"],
 	[-12.0, 13.0, 14.0, 20.5, "TRUE", "False"],
 ]
 
 # With Detect Booleans enabled
 [
-	["Apple", "Banana", "Cherry", "Durian", "Feijoa", "Eggplant"],
+	["Apple", "Banana", "Cherry", "Durian", "Eggplant", "Feijoa"],
 	["-12", "13", "14.0", "20.5", true, false],
 ]
 
 # With "Detect Numbers" enabled, "Detect Booleans" enabled and "Force Float" disabled
 [
-	["Apple", "Banana", "Cherry", "Durian", "Feijoa", "Eggplant"],
+	["Apple", "Banana", "Cherry", "Durian", "Eggplant", "Feijoa"],
 	[
 		-12,   # int
 		13,    # int

--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ an array of string arrays by default.
 	* Convert fields from string to `int` or `float` when possible.
 * **Force Float**
 	* Always use `float` when detecting numbers.
+* **Detect Booleans**
+	* Convert fields from string to `false` or `true` when case-insetively detecting according strings.
 
 ## Example
 
 After importing `res://example.csv`:
 
 ```csv
-Apple,Banana,Cherry,Durian
--12,13,14.0,20.5
+Apple,Banana,Cherry,Durian,Feijoa,Eggplant
+-12,13,14.0,20.5,TRUE,False
 ```
 
 The value of `preload("res://example.csv").records` will be:
@@ -51,8 +53,8 @@ The value of `preload("res://example.csv").records` will be:
 ```gdscript
 # By default
 [
-	["Apple", "Banana", "Cherry", "Durian"],
-	["-12", "13", "14.0", "20.5"],
+	["Apple", "Banana", "Cherry", "Durian", "Feijoa", "Eggplant"],
+	["-12", "13", "14.0", "20.5", "TRUE", "False"],
 ]
 
 # With "Headers" enabled
@@ -62,22 +64,33 @@ The value of `preload("res://example.csv").records` will be:
 		"Banana": "13",
 		"Cherry": "14.0",
 		"Durian": "20.5",
+		"Feijoa": "TRUE",
+		"Eggplant": "False,
 	},
 ]
 
 # With "Detect Numbers" and "Force Float" enabled
 [
-	["Apple", "Banana", "Cherry", "Durian"],
-	[-12.0, 13.0, 14.0, 20.5],
+	["Apple", "Banana", "Cherry", "Durian", "Feijoa", "Eggplant"],
+	[-12.0, 13.0, 14.0, 20.5, "TRUE", "False"],
+]
 
-# With "Detect Numbers" enabled and "Force Float" disabled
+# With Detect Booleans enabled
 [
-	["Apple", "Banana", "Cherry", "Durian"],
+	["Apple", "Banana", "Cherry", "Durian", "Feijoa", "Eggplant"],
+	["-12", "13", "14.0", "20.5", true, false],
+]
+
+# With "Detect Numbers" enabled, "Detect Booleans" enabled and "Force Float" disabled
+[
+	["Apple", "Banana", "Cherry", "Durian", "Feijoa", "Eggplant"],
 	[
 		-12,   # int
 		13,    # int
 		14.0,  # float
 		20.5,  # float
+		true,  # bool
+		false, # bool
 	],
 ]
 ```

--- a/addons/csv-data-importer/import_plugin.gd
+++ b/addons/csv-data-importer/import_plugin.gd
@@ -104,7 +104,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 					detected.append(float(field))
 					continue
 				if options.detect_booleans:
-					if field.nocasecmp_to("false") == 0: 
+					if field.nocasecmp_to("false") == 0:
 						detected.append(false)
 						continue
 					if field.nocasecmp_to("true") == 0:

--- a/addons/csv-data-importer/import_plugin.gd
+++ b/addons/csv-data-importer/import_plugin.gd
@@ -67,6 +67,7 @@ func _get_import_options(_path, preset):
 		{name="headers", default_value=headers},
 		{name="detect_numbers", default_value=false},
 		{name="force_float", default_value=true},
+		{name="detect_booleans", default_value=false},
 	]
 
 
@@ -93,15 +94,25 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var lines = []
 	while not file.eof_reached():
 		var line = file.get_csv_line(delim)
-		if options.detect_numbers and (not options.headers or lines.size() > 0):
+		if not options.headers or lines.size() > 0:
 			var detected := []
 			for field in line:
-				if not options.force_float and field.is_valid_int():
-					detected.append(int(field))
-				elif field.is_valid_float():
-					detected.append(float(field))
-				else:
-					detected.append(field)
+				if options.detect_numbers and field.is_valid_float(): # Any valid integer is also a valid float
+					if not options.force_float and field.is_valid_int():
+						detected.append(int(field))
+						continue
+					elif field.is_valid_float():
+						detected.append(float(field))
+						continue
+				if options.detect_booleans:
+					if field.nocasecmp_to("false") == 0: 
+						detected.append(bool(false))
+						continue
+					elif field.nocasecmp_to("true") == 0:
+						detected.append(bool(true))
+						continue
+
+				detected.append(field)
 			lines.append(detected)
 		else:
 			lines.append(line)

--- a/addons/csv-data-importer/import_plugin.gd
+++ b/addons/csv-data-importer/import_plugin.gd
@@ -97,21 +97,19 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		if not options.headers or lines.size() > 0:
 			var detected := []
 			for field in line:
-				if options.detect_numbers and field.is_valid_float(): # Any valid integer is also a valid float
+				if options.detect_numbers and field.is_valid_float():
 					if not options.force_float and field.is_valid_int():
 						detected.append(int(field))
 						continue
-					elif field.is_valid_float():
-						detected.append(float(field))
-						continue
+					detected.append(float(field))
+					continue
 				if options.detect_booleans:
 					if field.nocasecmp_to("false") == 0: 
-						detected.append(bool(false))
+						detected.append(false)
 						continue
-					elif field.nocasecmp_to("true") == 0:
-						detected.append(bool(true))
+					if field.nocasecmp_to("true") == 0:
+						detected.append(true)
 						continue
-
 				detected.append(field)
 			lines.append(detected)
 		else:


### PR DESCRIPTION
Added detection for boolean types. Some users may use spreadsheets to calculate formulas that produce boolean outputs. Typically, when exporting, these values are written as "TRUE" or "FALSE." I have implemented a case-insensitive solution in case users manually enter boolean fields in their CSV files using different capitalization conventions.